### PR TITLE
Move answer evaluation logic to server

### DIFF
--- a/app/components/testDebug.vue
+++ b/app/components/testDebug.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 defineProps<{
-  state: Record<string, any>
+  state: Record<string, unknown>
 }>()
 </script>
 <template> 

--- a/app/composables/useForm.ts
+++ b/app/composables/useForm.ts
@@ -1,8 +1,12 @@
 import { useToast } from '#imports'
 import type { FormError, FormSubmitEvent } from '@nuxt/ui'
-import { evaluateAnswers, type EvaluationResult } from '../utils/evaluateAnswers'
 
-export function useForm(formConfig: Test.FormConfig) {
+export interface EvaluationResult {
+  total: number
+  max: number
+}
+
+export function useForm(formConfig: Test.FormConfig, testId: string) {
   const initialState: Test.FormState = {}
 
   // TODO: Add types
@@ -82,13 +86,12 @@ export function useForm(formConfig: Test.FormConfig) {
   const toast = useToast()
 
   const onSubmit = async (event: FormSubmitEvent<Test.FormState>) => {
-
-    // TODO: Fetch require to server api
-    result.value = evaluateAnswers(
-      formConfig as Test.FormConfig & {
-        fields: Array<Test.FormField & { correct?: string[]; points?: number }>
-      },
-      event.data
+    result.value = await $fetch<EvaluationResult>(
+      `/api/tests/${testId}/evaluate`,
+      {
+        method: 'POST',
+        body: event.data
+      }
     )
 
     toast.add({

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -53,7 +53,8 @@ const navItems = [
 
 <template>
   <!-- <UContainer class="flex flex-col bg-neutral-100 "></UContainer> -->
-  <div class="flex flex-col bg-neutral-100 ">
+  <div>
+    <div class="flex flex-col bg-neutral-100 ">
     <!-- Header как отдельный компонент -->
     <header>
         <div class="flex items-center justify-between p-4 ">
@@ -96,8 +97,9 @@ const navItems = [
           </div>
         </div>
     </header>
-  </div>
-  <div>
-  <slot />
+    </div>
+    <div>
+      <slot />
+    </div>
   </div>
 </template>

--- a/app/pages/test/[id]/index.vue
+++ b/app/pages/test/[id]/index.vue
@@ -7,7 +7,7 @@ const id = route.params.id as string
 
 const { data: formConfig } = await useFetch<Test.FormConfig>(`/api/tests/${id}`)
 
-const { state, validate, onSubmit, result } = useForm(formConfig.value)
+const { state, validate, onSubmit, result } = useForm(formConfig.value, id)
 </script>
 
 <template>

--- a/exaple1.vue
+++ b/exaple1.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/multi-word-component-names -->
 <script setup lang="ts">
 
 // Type definitions

--- a/index.vue
+++ b/index.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/multi-word-component-names -->
 <script setup lang="ts">
 
 // Type definitions

--- a/server/api/tests/[id]/evaluate.post.ts
+++ b/server/api/tests/[id]/evaluate.post.ts
@@ -1,0 +1,17 @@
+import { promises as fs } from 'node:fs'
+import { join } from 'node:path'
+import type { H3Event } from 'h3'
+import { evaluateAnswers } from '../../utils/evaluateAnswers'
+
+export default defineEventHandler(async (event: H3Event) => {
+  const { id } = event.context.params!
+  const body = await readBody<Test.FormState>(event)
+
+  const path = join(process.cwd(), 'data', `${id}.json`)
+  const file = await fs.readFile(path, 'utf-8')
+  const config = JSON.parse(file) as Test.FormConfig & {
+    fields: Array<Test.FormField & { correct?: string[]; points?: number }>
+  }
+
+  return evaluateAnswers(config, body)
+})

--- a/server/api/tests/[id]/evaluate.post.ts
+++ b/server/api/tests/[id]/evaluate.post.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'node:fs'
 import { join } from 'node:path'
 import type { H3Event } from 'h3'
-import { evaluateAnswers } from '../../utils/evaluateAnswers'
+import { evaluateAnswers } from '../../../utils/evaluateAnswers'
 
 export default defineEventHandler(async (event: H3Event) => {
   const { id } = event.context.params!

--- a/server/utils/evaluateAnswers.ts
+++ b/server/utils/evaluateAnswers.ts
@@ -1,4 +1,3 @@
-// TODO: Transfer to server side
 export interface EvaluationResult {
   total: number
   max: number
@@ -7,7 +6,12 @@ export interface EvaluationResult {
 /**
  * Compare user answers with correct answers and calculate score
  */
-export function evaluateAnswers(config: Test.FormConfig & { fields: Array<Test.FormField & { correct?: string[]; points?: number }> }, state: Test.FormState): EvaluationResult {
+export function evaluateAnswers(
+  config: Test.FormConfig & {
+    fields: Array<Test.FormField & { correct?: string[]; points?: number }>
+  },
+  state: Test.FormState
+): EvaluationResult {
   let total = 0
   let max = 0
 
@@ -20,7 +24,9 @@ export function evaluateAnswers(config: Test.FormConfig & { fields: Array<Test.F
     if (!points) continue
 
     if (Array.isArray(value)) {
-      const isCorrect = correct.every((c) => value.includes(c)) && value.length === correct.length
+      const isCorrect =
+        correct.every((c) => (value as string[]).includes(c)) &&
+        (value as string[]).length === correct.length
       if (isCorrect) total += points
     } else if (typeof value === 'string') {
       if (correct.includes(value)) total += points


### PR DESCRIPTION
## Summary
- relocate `evaluateAnswers` util from client-side to server utils
- provide POST API `/api/tests/[id]/evaluate` for score calculation
- update form composable to submit answers via new API
- adjust dynamic test page to pass test ID

## Testing
- `pnpm lint` *(fails: cannot find `.nuxt/eslint.config.mjs`)*

------
https://chatgpt.com/codex/tasks/task_e_6861696bcf6c8322807e68d25baa3ce3