### PR TITLE
Add edit mode for tests

### DIFF
--- a/app/pages/test/[id]/edit.vue
+++ b/app/pages/test/[id]/edit.vue
@@ -1,0 +1,262 @@
+<template>
+  <div class="p-4 space-y-6">
+    <!-- Заголовок теста -->
+    <UInput
+      v-model="test.fileName"
+      label="File Name"
+      placeholder="example.json"
+    />
+    <UInput v-model="test.title" label="Title" />
+    <UTextarea v-model="test.description" label="Description" />
+
+    <!-- Список полей -->
+    <div
+      v-for="(field, index) in test.fields"
+      :key="field.id"
+      class="p-4 border rounded-md space-y-2 bg-neutral-100"
+    >
+      <div class="flex justify-between items-center">
+        <span class="font-bold">Field {{ index + 1 }}</span>
+        <UButton
+          size="xs"
+          color="red"
+          icon="i-lucide-x"
+          @click="removeField(index)"
+        />
+      </div>
+
+      <UInput v-model.number="field.id" type="number" label="Id" disabled />
+      <UInput v-model="field.name" label="Name" />
+      <UInput v-model="field.label" label="Label" />
+      <UInput v-model="field.question" label="Question" />
+
+      <!-- Радиокнопки выбора типа -->
+      <label class="font-bold block">Type</label>
+      <div class="flex flex-wrap gap-4">
+        <label
+          v-for="opt in fieldTypes"
+          :key="`${field.id}-${opt.value}`"
+          class="inline-flex items-center gap-1 cursor-pointer"
+        >
+          <input
+            type="radio"
+            :value="opt.value"
+            v-model="field.type"
+            class="h-4 w-4 accent-blue-600"
+          />
+          <span>{{ opt.label }}</span>
+        </label>
+      </div>
+
+      <UCheckbox v-model="field.required" label="Required" />
+      <UInput v-model.number="field.points" type="number" label="Points" />
+      <UInput v-model="field.placeholder" label="Placeholder" />
+      <UInput v-model="field.correctCsv" label="Correct (comma separated)" />
+
+      <!-- Опции -->
+      <div class="space-y-2">
+        <div
+          v-for="(opt, idx) in field.options"
+          :key="idx"
+          class="flex gap-2 items-center"
+        >
+          <UInput v-model="opt.label" label="Option Label" class="flex-1" />
+          <UInput v-model="opt.value" label="Option Value" class="flex-1" />
+          <UButton
+            size="xs"
+            color="red"
+            icon="i-lucide-x"
+            @click="removeOption(field, idx)"
+          />
+        </div>
+        <UButton size="xs" color="primary" @click="addOption(field)"
+          >Add option</UButton
+        >
+      </div>
+    </div>
+
+    <!-- Добавление поля -->
+    <div class="space-y-2">
+      <label class="font-bold block">New Field Type</label>
+      <div class="flex flex-wrap gap-4">
+        <label
+          v-for="opt in fieldTypes"
+          :key="'new-' + opt.value"
+          class="inline-flex items-center gap-1 cursor-pointer"
+        >
+          <input
+            type="radio"
+            :value="opt.value"
+            v-model="newFieldType"
+            class="h-4 w-4 accent-blue-600"
+          />
+          <span>{{ opt.label }}</span>
+        </label>
+      </div>
+
+      <div class="flex gap-2 pt-2">
+        <UButton color="primary" @click="addField">Add field</UButton>
+        <UButton color="primary" @click="submit">Submit</UButton>
+      </div>
+    </div>
+
+    <!-- Превью JSON -->
+    <pre class="bg-neutral-200 p-2 text-xs overflow-auto"
+      >{{ JSON.stringify(preview, null, 2) }}
+</pre
+    >
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { reactive, computed, ref } from "vue";
+import { useToast } from "#imports";
+import { useRoute } from "vue-router";
+const route = useRoute();
+const id = route.params.id as string;
+const { data: loaded } = await useFetch<Test.FormConfig>(`/api/tests/${id}`);
+
+/* ---------- Типы ---------- */
+interface Option {
+  label: string;
+  value: string;
+}
+
+const fieldTypes = [
+  { label: "Text", value: "text" },
+  { label: "Number", value: "number" },
+  { label: "Textarea", value: "textarea" },
+  { label: "Radio buttons", value: "radioButton" },
+  { label: "Checkbox group", value: "checkboxGroup" },
+] as const;
+
+type FieldType = (typeof fieldTypes)[number]["value"]; // 'text' | 'number' | ...
+
+interface FieldForm {
+  id: number;
+  name: string;
+  label: string;
+  question: string;
+  type: FieldType;
+  required: boolean;
+  points: number;
+  placeholder?: string;
+  correctCsv: string;
+  options: Option[];
+}
+
+/* ---------- Состояние ---------- */
+const newFieldType = ref<FieldType>("text");
+
+const test = reactive<{
+  fileName: string;
+  title: string;
+  description: string;
+  fields: FieldForm[];
+}>({
+  fileName: "",
+  title: "",
+  description: "",
+  fields: [],
+});
+
+if (loaded.value) {
+  test.fileName = loaded.value.fileName;
+  test.title = loaded.value.title;
+  test.description = loaded.value.description;
+  test.fields = loaded.value.fields.map((f) => ({
+    id: f.id,
+    name: f.name,
+    label: f.label,
+    question: f.question,
+    type: f.type as FieldType,
+    required: f.required,
+    points: f.points,
+    placeholder: f.placeholder,
+    correctCsv: (f.correct ?? []).join(', '),
+    options: f.options ? [...f.options] : [],
+  }));
+}
+
+/* ---------- CRUD ---------- */
+function addField() {
+  const nextId = test.fields.length
+    ? Math.max(...test.fields.map((f) => f.id)) + 1
+    : 1;
+  test.fields.push({
+    id: nextId,
+    name: "",
+    label: "",
+    question: "",
+    type: newFieldType.value,
+    required: false,
+    points: 0,
+    placeholder: "",
+    correctCsv: "",
+    options: [],
+  });
+}
+
+function removeField(index: number) {
+  test.fields.splice(index, 1);
+}
+
+function addOption(field: FieldForm) {
+  field.options.push({ label: "", value: "" });
+}
+
+function removeOption(field: FieldForm, idx: number) {
+  field.options.splice(idx, 1);
+}
+
+/* ---------- Превью ---------- */
+const preview = computed(() => ({
+  fileName: test.fileName,
+  title: test.title,
+  description: test.description,
+  fields: test.fields.map((f) => ({
+    id: f.id,
+    name: f.name,
+    label: f.label,
+    question: f.question,
+    type: f.type,
+    required: f.required,
+    points: f.points,
+    correct: f.correctCsv
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean),
+    placeholder: f.placeholder || undefined,
+    options: f.options.length ? f.options : undefined,
+    multiple: f.type === "checkboxGroup",
+  })),
+}));
+
+/* ---------- Отправка ---------- */
+const toast = useToast();
+
+async function submit() {
+  try {
+    await $fetch(`/api/tests/${id}/update`, {
+      method: "POST",
+      body: preview.value,
+    });
+    toast.add({
+      title: "Success",
+      description: "Test saved",
+      color: "primary",
+    });
+  } catch (err) {
+    toast.add({
+      title: "Error",
+      description: "Failed to save test",
+      color: "red",
+    });
+    console.error(err);
+  }
+}
+</script>
+
+<style>
+/* при необходимости — кастомные стили */
+</style>

--- a/app/pages/test/[id]/edit.vue
+++ b/app/pages/test/[id]/edit.vue
@@ -4,7 +4,7 @@
     <UInput
       v-model="test.fileName"
       label="File Name"
-      placeholder="example.json"
+      disabled
     />
     <UInput v-model="test.title" label="Title" />
     <UTextarea v-model="test.description" label="Description" />

--- a/app/pages/test/[id]/index.vue
+++ b/app/pages/test/[id]/index.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import { useUserStore } from "~/stores/user";
+import { useEditStore } from "~/stores/edit";
 
 const user = useUserStore();
+const edit = useEditStore();
 const route = useRoute()
 const id = route.params.id as string
 
@@ -17,8 +19,13 @@ const { state, validate, onSubmit, result } = useForm(formConfig.value, id)
         {{ formConfig.title }}
       </h1>
       <p class="text-gray-600 dark:text-gray-400">
-        {{ formConfig.description }}  
+        {{ formConfig.description }}
       </p>
+      <div v-if="edit.isEditMode" class="mt-4 text-right">
+        <NuxtLink :to="`/test/${id}/edit`">
+          <UButton size="sm" color="primary" icon="i-lucide-pen">Edit</UButton>
+        </NuxtLink>
+      </div>
     </div>
 
     <UForm :validate="validate" :state="state" class="space-y-6" @submit="onSubmit">

--- a/server/api/tests/[id]/update.post.ts
+++ b/server/api/tests/[id]/update.post.ts
@@ -1,0 +1,30 @@
+import { defineEventHandler, readBody, createError } from 'h3';
+import type { H3Event } from 'h3';
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { testSchema } from '../../schema/test';
+
+export default defineEventHandler(async (event: H3Event) => {
+  if (event.method !== 'POST') {
+    throw createError({ statusCode: 405, statusMessage: 'Method Not Allowed' });
+  }
+
+  const { id } = event.context.params as { id: string };
+  const body = await readBody<Record<string, unknown>>(event);
+
+  const parsed = testSchema.safeParse(body);
+  if (!parsed.success) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Validation error',
+      data: parsed.error.format(),
+    });
+  }
+
+  const dir = join(process.cwd(), 'data');
+  const filePath = join(dir, `${id}.json`);
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(filePath, JSON.stringify(parsed.data, null, 2), 'utf8');
+
+  return { success: true, file: `${id}.json` };
+});

--- a/server/api/tests/[id]/update.post.ts
+++ b/server/api/tests/[id]/update.post.ts
@@ -12,7 +12,11 @@ export default defineEventHandler(async (event: H3Event) => {
   const { id } = event.context.params as { id: string };
   const body = await readBody<Record<string, unknown>>(event);
 
-  const parsed = testSchema.safeParse(body);
+  // Always enforce original file name
+  const parsed = testSchema.safeParse({
+    ...body,
+    fileName: `${id}.json`,
+  });
   if (!parsed.success) {
     throw createError({
       statusCode: 400,


### PR DESCRIPTION
## Summary
- create `/api/tests/[id]/update` to save edited test JSON
- add new `test/[id]/edit` page based on `makeNewTest` to modify existing tests
- expose edit link from `/test/[id]` when edit mode is active

## Testing
- `npm run lint` *(fails: Cannot find module '/workspace/TestingApp/.nuxt/eslint.config.mjs')*

------
https://chatgpt.com/codex/tasks/task_e_686172122e4483229319345cea020c92