### PR TITLE
Update test field types

### DIFF
--- a/app/components/fields/data/edit.vue
+++ b/app/components/fields/data/edit.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>Data edit component</div>
+</template>

--- a/app/components/fields/data/index.vue
+++ b/app/components/fields/data/index.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+const props = defineProps<{ field: Test.FormField; modelValue: string | undefined }>()
+const emit = defineEmits<(e: 'update:modelValue', value: string | undefined) => void>()
+</script>
+<template>
+  <UInput
+    type="date"
+    :name="props.field.name"
+    :placeholder="props.field.placeholder"
+    :model-value="props.modelValue"
+    @update:model-value="val => emit('update:modelValue', val as string | undefined)"
+  />
+</template>

--- a/app/components/fields/flag/edit.vue
+++ b/app/components/fields/flag/edit.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>Flag edit component</div>
+</template>

--- a/app/components/fields/flag/index.vue
+++ b/app/components/fields/flag/index.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+const props = defineProps<{ field: Test.FormField; modelValue: string | undefined }>()
+const emit = defineEmits<(e: 'update:modelValue', value: string | undefined) => void>()
+</script>
+<template>
+  <URadioGroup
+    :label="props.field.label"
+    :model-value="props.modelValue"
+    :items="props.field.options?.map(o => ({ label: o.label, value: o.value })) || []"
+    size="xl"
+    variant="card"
+    @update:model-value="val => emit('update:modelValue', val as string | undefined)"
+  />
+</template>

--- a/app/components/fields/input/edit.vue
+++ b/app/components/fields/input/edit.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>Input edit component</div>
+</template>

--- a/app/components/fields/input/index.vue
+++ b/app/components/fields/input/index.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+const props = defineProps<{ field: Test.FormField; modelValue: number | undefined }>()
+const emit = defineEmits<(e: 'update:modelValue', value: number | undefined) => void>()
+</script>
+<template>
+  <UInput
+    type="number"
+    :name="props.field.name"
+    :placeholder="props.field.placeholder"
+    :model-value="props.modelValue"
+    @update:model-value="val => emit('update:modelValue', val as number | undefined)"
+  />
+</template>

--- a/app/components/fields/quiz/edit.vue
+++ b/app/components/fields/quiz/edit.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>Quiz edit component</div>
+</template>

--- a/app/components/fields/quiz/index.vue
+++ b/app/components/fields/quiz/index.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+const props = defineProps<{ field: Test.FormField; modelValue: string[] }>()
+const emit = defineEmits<(e: 'update:modelValue', value: string[]) => void>()
+</script>
+<template>
+  <UCheckboxGroup
+    color="primary"
+    variant="card"
+    size="xl"
+    :model-value="props.modelValue"
+    :items="props.field.options?.map(o => ({ label: o.label, value: o.value })) || []"
+    @update:model-value="val => emit('update:modelValue', val as string[])"
+  />
+</template>

--- a/app/components/fields/text/edit.vue
+++ b/app/components/fields/text/edit.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>Text edit component</div>
+</template>

--- a/app/components/fields/text/index.vue
+++ b/app/components/fields/text/index.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+const props = defineProps<{ field: Test.FormField; modelValue: string | number | undefined }>()
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: string | number | undefined): void
+}>()
+</script>
+<template>
+  <UInput
+    :name="props.field.name"
+    :placeholder="props.field.placeholder"
+    :model-value="props.modelValue"
+    @update:model-value="val => emit('update:modelValue', val)"
+  />
+</template>

--- a/app/composables/useForm.ts
+++ b/app/composables/useForm.ts
@@ -11,7 +11,7 @@ export function useForm(formConfig: Test.FormConfig, testId: string) {
 
   // TODO: Add types
   formConfig.fields.forEach((field) => {
-    if (field.type === 'checkboxGroup') {
+    if (field.type === 'quiz') {
       initialState[field.name] = []
     } else {
       initialState[field.name] = undefined

--- a/app/pages/makeNewTest.vue
+++ b/app/pages/makeNewTest.vue
@@ -119,14 +119,14 @@ interface Option {
 }
 
 const fieldTypes = [
+  { label: "Quiz", value: "quiz" },
+  { label: "Flag", value: "flag" },
+  { label: "Data", value: "data" },
+  { label: "Input", value: "input" },
   { label: "Text", value: "text" },
-  { label: "Number", value: "number" },
-  { label: "Textarea", value: "textarea" },
-  { label: "Radio buttons", value: "radioButton" },
-  { label: "Checkbox group", value: "checkboxGroup" },
 ] as const;
 
-type FieldType = (typeof fieldTypes)[number]["value"]; // 'text' | 'number' | ...
+type FieldType = (typeof fieldTypes)[number]["value"]; // 'quiz' | 'flag' | ...
 
 interface FieldForm {
   id: number;
@@ -206,7 +206,7 @@ const preview = computed(() => ({
       .filter(Boolean),
     placeholder: f.placeholder || undefined,
     options: f.options.length ? f.options : undefined,
-    multiple: f.type === "checkboxGroup",
+    multiple: f.type === "quiz",
   })),
 }));
 

--- a/app/pages/test/[id]/edit.vue
+++ b/app/pages/test/[id]/edit.vue
@@ -122,14 +122,14 @@ interface Option {
 }
 
 const fieldTypes = [
+  { label: "Quiz", value: "quiz" },
+  { label: "Flag", value: "flag" },
+  { label: "Data", value: "data" },
+  { label: "Input", value: "input" },
   { label: "Text", value: "text" },
-  { label: "Number", value: "number" },
-  { label: "Textarea", value: "textarea" },
-  { label: "Radio buttons", value: "radioButton" },
-  { label: "Checkbox group", value: "checkboxGroup" },
 ] as const;
 
-type FieldType = (typeof fieldTypes)[number]["value"]; // 'text' | 'number' | ...
+type FieldType = (typeof fieldTypes)[number]["value"]; // 'quiz' | 'flag' | ...
 
 interface FieldForm {
   id: number;
@@ -227,7 +227,7 @@ const preview = computed(() => ({
       .filter(Boolean),
     placeholder: f.placeholder || undefined,
     options: f.options.length ? f.options : undefined,
-    multiple: f.type === "checkboxGroup",
+    multiple: f.type === "quiz",
   })),
 }));
 

--- a/app/pages/test1.vue
+++ b/app/pages/test1.vue
@@ -7,7 +7,7 @@ interface FormField {
   id: number
   name: string
   label: string
-  type: 'text'| 'number' | 'textarea' | 'checkboxGroup' | 'radioButton'
+  type: 'quiz' | 'flag' | 'data' | 'input' | 'text'
   question: string
   placeholder?: string
   required: boolean
@@ -41,7 +41,7 @@ const formConfig: FormConfig = {
       id: 1,
       name: 'interests',
       label: 'Interests',
-      type: 'radioButton',
+      type: 'flag',
       question: 'Interests',
       required: false,
       options: [
@@ -57,7 +57,7 @@ const formConfig: FormConfig = {
       id: 2,
       name: 'newsletter',
       label: 'Subscribe to Newsletter',
-      type: 'checkboxGroup',
+      type: 'quiz',
       question: 'Subscribe to Newsletter',
       required: false,
       options: [
@@ -71,7 +71,7 @@ const formConfig: FormConfig = {
       id: 3,
       name: 'quizQuestion1',
       label: 'What is your preferred programming language?',
-      type: 'checkboxGroup',
+      type: 'quiz',
       question: 'What is your preferred programming language?',
       required: true,
       options: [
@@ -87,7 +87,7 @@ const formConfig: FormConfig = {
       id: 4,
       name: 'quizQuestion2',
       label: 'Which development methodologies do you use?',
-      type: 'checkboxGroup',
+      type: 'quiz',
       question: 'Which development methodologies do you use?',
       required: false,
       options: [
@@ -103,7 +103,7 @@ const formConfig: FormConfig = {
       id: 5,
       name: 'feedback',
       label: 'feedback',
-      type: 'textarea',
+      type: 'text',
       question: 'Enter you feedback ',
       required: false,
     },
@@ -114,7 +114,7 @@ const formConfig: FormConfig = {
 // Create reactive state from form config
 const initialState: FormState = {}
 formConfig.fields.forEach(field => {
-  if (field.type === 'checkboxGroup') {
+  if (field.type === 'quiz') {
     initialState[field.name] = []
   } else {
     initialState[field.name] = undefined
@@ -222,24 +222,30 @@ const renderField = (field: FormField) => {
   
   switch (field.type) {
     case 'text':
-    case 'number':
       return h(UInput, {
         ...commonProps,
-        type: field.type,
-        modelValue: state[field.name] as string | number,
-        'onUpdate:modelValue': (value: string | number) => state[field.name] = value
-      })
-    
-    case 'textarea':
-      return h(UTextarea, {
-        ...commonProps,
-        rows: 4,
+        type: 'text',
         modelValue: state[field.name] as string,
-        'onUpdate:modelValue': (value: string) => state[field.name] = value,
-        size: 'lg',
+        'onUpdate:modelValue': (value: string) => state[field.name] = value
+      })
+
+    case 'input':
+      return h(UInput, {
+        ...commonProps,
+        type: 'number',
+        modelValue: state[field.name] as number,
+        'onUpdate:modelValue': (value: number) => state[field.name] = value
+      })
+
+    case 'data':
+      return h(UInput, {
+        ...commonProps,
+        type: 'date',
+        modelValue: state[field.name] as string,
+        'onUpdate:modelValue': (value: string) => state[field.name] = value
       })
     
-    case 'radioButton':
+    case 'flag':
       return h(URadioGroup, {
         label: field.label,
         size:"xl",
@@ -252,7 +258,7 @@ const renderField = (field: FormField) => {
         })) || []
       })
     
-    case 'checkboxGroup':
+    case 'quiz':
       // Use UCheckboxGroup with card variant
       return h(UCheckboxGroup, {
         color: 'primary',

--- a/app/utils/renderField.ts
+++ b/app/utils/renderField.ts
@@ -1,46 +1,43 @@
 import { h } from 'vue'
-import { UInput, UTextarea, UCheckboxGroup, URadioGroup } from '#components'
+import {
+  FieldsText,
+  FieldsInput,
+  FieldsData,
+  FieldsFlag,
+  FieldsQuiz,
+} from '#components'
 
 export function renderField(field: Test.FormField, state: Test.FormState) {
-  const commonProps = {
-    name: field.name,
-    placeholder: field.placeholder
-  }
-
   switch (field.type) {
     case 'text':
-    case 'number':
-      return h(UInput, {
-        ...commonProps,
-        type: field.type,
-        modelValue: state[field.name] as string | number,
-        'onUpdate:modelValue': (value: string | number) => (state[field.name] = value)
-      })
-    case 'textarea':
-      return h(UTextarea, {
-        ...commonProps,
-        rows: 4,
+      return h(FieldsText, {
+        field,
         modelValue: state[field.name] as string,
         'onUpdate:modelValue': (value: string) => (state[field.name] = value),
-        size: 'lg'
       })
-    case 'radioButton':
-      return h(URadioGroup, {
-        label: field.label,
-        size: 'xl',
-        variant: 'card',
+    case 'input':
+      return h(FieldsInput, {
+        field,
+        modelValue: state[field.name] as number,
+        'onUpdate:modelValue': (value: number) => (state[field.name] = value),
+      })
+    case 'data':
+      return h(FieldsData, {
+        field,
+        modelValue: state[field.name] as string,
+        'onUpdate:modelValue': (value: string) => (state[field.name] = value),
+      })
+    case 'flag':
+      return h(FieldsFlag, {
+        field,
+        modelValue: state[field.name] as string,
+        'onUpdate:modelValue': (value: string) => (state[field.name] = value),
+      })
+    case 'quiz':
+      return h(FieldsQuiz, {
+        field,
         modelValue: state[field.name] as string[],
         'onUpdate:modelValue': (value: string[]) => (state[field.name] = value),
-        items: field.options?.map((option) => ({ label: option.label, value: option.value })) || []
-      })
-    case 'checkboxGroup':
-      return h(UCheckboxGroup, {
-        color: 'primary',
-        variant: 'card',
-        size: 'xl',
-        modelValue: state[field.name] as string[],
-        'onUpdate:modelValue': (value: string[]) => (state[field.name] = value),
-        items: field.options?.map((option) => ({ label: option.label, value: option.value })) || []
       })
     default:
       return h('div', `Unknown field type: ${field.type}`)

--- a/data/123.json
+++ b/data/123.json
@@ -8,7 +8,7 @@
       "name": "123",
       "label": "123",
       "question": "123",
-      "type": "number",
+      "type": "input",
       "required": true,
       "points": 0,
       "correct": [

--- a/data/2.json
+++ b/data/2.json
@@ -8,7 +8,7 @@
       "name": "123",
       "label": "123",
       "question": "123",
-      "type": "checkboxGroup",
+      "type": "quiz",
       "required": true,
       "points": 123,
       "correct": [

--- a/data/new.json
+++ b/data/new.json
@@ -8,7 +8,7 @@
       "name": "interests",
       "label": "Interests",
       "question": "Interests",
-      "type": "radioButton",
+      "type": "flag",
       "required": false,
       "points": 1,
       "correct": [
@@ -46,7 +46,7 @@
       "name": "newsletter",
       "label": "Subscribe to Newsletter",
       "question": "Subscribe to Newsletter",
-      "type": "checkboxGroup",
+      "type": "quiz",
       "required": false,
       "points": 2,
       "correct": [
@@ -73,7 +73,7 @@
       "name": "quizQuestion1",
       "label": "What is your preferred programming language?",
       "question": "What is your preferred programming language?",
-      "type": "checkboxGroup",
+      "type": "quiz",
       "required": true,
       "points": 3,
       "correct": [
@@ -111,7 +111,7 @@
       "name": "quizQuestion2",
       "label": "Which development methodologies do you use?",
       "question": "Which development methodologies do you use?",
-      "type": "checkboxGroup",
+      "type": "quiz",
       "required": false,
       "points": 2,
       "correct": [
@@ -150,7 +150,7 @@
       "name": "feedback",
       "label": "feedback",
       "question": "Enter you feedback ",
-      "type": "textarea",
+      "type": "text",
       "required": false,
       "points": 0,
       "correct": []

--- a/data/sql_test.json
+++ b/data/sql_test.json
@@ -7,7 +7,7 @@
       "name": "q1",
       "label": "What does SQL stand for?",
       "question": "What does SQL stand for?",
-      "type": "radioButton",
+      "type": "flag",
       "required": true,
       "points": 1,
       "correct": [
@@ -33,7 +33,7 @@
       "name": "q2",
       "label": "Keyword for retrieving data",
       "question": "Which SQL keyword is used to retrieve data from a table?",
-      "type": "radioButton",
+      "type": "flag",
       "required": true,
       "points": 1,
       "correct": [
@@ -59,7 +59,7 @@
       "name": "q3",
       "label": "Filter rows",
       "question": "Which clause is used to filter rows returned by a query?",
-      "type": "radioButton",
+      "type": "flag",
       "required": true,
       "points": 1,
       "correct": [
@@ -85,7 +85,7 @@
       "name": "q4",
       "label": "Update statement",
       "question": "Which SQL statement is used to modify existing rows?",
-      "type": "radioButton",
+      "type": "flag",
       "required": true,
       "points": 1,
       "correct": [
@@ -111,7 +111,7 @@
       "name": "q5",
       "label": "Aggregate functions",
       "question": "Choose all SQL aggregate functions:",
-      "type": "checkboxGroup",
+      "type": "quiz",
       "required": true,
       "points": 2,
       "correct": [
@@ -143,7 +143,7 @@
       "name": "q6",
       "label": "Primary key uniqueness",
       "question": "True or False: A PRIMARY KEY must contain unique, non-null values.",
-      "type": "radioButton",
+      "type": "flag",
       "required": true,
       "points": 1,
       "correct": [
@@ -165,7 +165,7 @@
       "name": "q7",
       "label": "DDL commands",
       "question": "Select all Data Definition Language (DDL) commands:",
-      "type": "checkboxGroup",
+      "type": "quiz",
       "required": true,
       "points": 2,
       "correct": [
@@ -197,7 +197,7 @@
       "name": "q8",
       "label": "INNER JOIN description",
       "question": "Describe what an INNER JOIN does:",
-      "type": "textarea",
+      "type": "text",
       "required": false,
       "points": 2,
       "correct": []
@@ -207,7 +207,7 @@
       "name": "q9",
       "label": "Column alias keyword",
       "question": "Which keyword assigns a column alias in SQL?",
-      "type": "radioButton",
+      "type": "flag",
       "required": true,
       "points": 1,
       "correct": [
@@ -233,7 +233,7 @@
       "name": "q10",
       "label": "Set operators",
       "question": "Pick the valid SQL set operators:",
-      "type": "checkboxGroup",
+      "type": "quiz",
       "required": true,
       "points": 2,
       "correct": [
@@ -265,7 +265,7 @@
       "name": "q11",
       "label": "Order results",
       "question": "Which clause is used to sort query results?",
-      "type": "radioButton",
+      "type": "flag",
       "required": true,
       "points": 1,
       "correct": [
@@ -291,7 +291,7 @@
       "name": "q12",
       "label": "Wildcard character",
       "question": "In SQL, which wildcard represents ANY sequence of characters?",
-      "type": "radioButton",
+      "type": "flag",
       "required": true,
       "points": 1,
       "correct": [
@@ -317,7 +317,7 @@
       "name": "q13",
       "label": "NOT NULL constraint",
       "question": "Explain the NOT NULL constraint purpose:",
-      "type": "textarea",
+      "type": "text",
       "required": false,
       "points": 2,
       "correct": []
@@ -327,7 +327,7 @@
       "name": "q14",
       "label": "Foreign key requirement",
       "question": "A FOREIGN KEY in one table must reference a ____ in another table.",
-      "type": "radioButton",
+      "type": "flag",
       "required": true,
       "points": 1,
       "correct": [
@@ -353,7 +353,7 @@
       "name": "q15",
       "label": "Transaction control",
       "question": "Choose all Transaction Control Language (TCL) commands:",
-      "type": "checkboxGroup",
+      "type": "quiz",
       "required": true,
       "points": 2,
       "correct": [
@@ -385,7 +385,7 @@
       "name": "q16",
       "label": "GROUP BY vs HAVING",
       "question": "Write the difference between GROUP BY and HAVING clauses:",
-      "type": "textarea",
+      "type": "text",
       "required": false,
       "points": 2,
       "correct": []
@@ -395,7 +395,7 @@
       "name": "q17",
       "label": "LIMIT support",
       "question": "Which databases support the LIMIT/OFFSET syntax? (Choose all that apply)",
-      "type": "checkboxGroup",
+      "type": "quiz",
       "required": true,
       "points": 2,
       "correct": [
@@ -427,7 +427,7 @@
       "name": "q18",
       "label": "Default sort direction",
       "question": "What is the default sorting order if ASC/DESC is not specified?",
-      "type": "radioButton",
+      "type": "flag",
       "required": true,
       "points": 1,
       "correct": [
@@ -449,7 +449,7 @@
       "name": "q19",
       "label": "DELETE vs TRUNCATE",
       "question": "Briefly explain the difference between DELETE and TRUNCATE:",
-      "type": "textarea",
+      "type": "text",
       "required": false,
       "points": 2,
       "correct": []
@@ -459,7 +459,7 @@
       "name": "q20",
       "label": "Subquery types",
       "question": "Select the valid subquery placement(s):",
-      "type": "checkboxGroup",
+      "type": "quiz",
       "required": true,
       "points": 2,
       "correct": [

--- a/server/api/schema/test.ts
+++ b/server/api/schema/test.ts
@@ -10,7 +10,7 @@ export const fieldSchema = z.object({
   name: z.string(),
   label: z.string(),
   question: z.string(),
-  type: z.enum(['text', 'number', 'textarea', 'radioButton', 'checkboxGroup']),
+  type: z.enum(['quiz', 'flag', 'data', 'input', 'text']),
   required: z.boolean(),
   points: z.number().int().nonnegative(),
   correct: z.array(z.string()),

--- a/types/tests.d.ts
+++ b/types/tests.d.ts
@@ -18,7 +18,7 @@ declare global {
       id: number;
       name: string;
       label: string;
-      type: "text" | "number" | "textarea" | "checkboxGroup";
+      type: "quiz" | "flag" | "data" | "input" | "text";
       placeholder?: string;
       required: boolean;
       validation?: {


### PR DESCRIPTION
## Summary
- expand `FormField.type` definitions to new structure
- update schema validation and form utils for new field types
- provide new form field components
- migrate pages and composables to new types
- convert existing test JSON data

## Testing
- `npm run lint` *(fails: Cannot find module '/workspace/TestingApp/.nuxt/eslint.config.mjs')*

------
https://chatgpt.com/codex/tasks/task_e_686257bc20348322bce52d0b394b3fac