### PR TITLE
Integrate field edit components

### DIFF
--- a/app/components/fields/FieldEditBase.vue
+++ b/app/components/fields/FieldEditBase.vue
@@ -56,8 +56,6 @@ const fieldTypes = [
     <USelect
       v-model="local.type"
       :options="fieldTypes"
-      option-attribute="label"
-      value-attribute="value"
       label="Type"
     />
     <UCheckbox v-model="local.required" label="Required" />

--- a/app/components/fields/FieldEditBase.vue
+++ b/app/components/fields/FieldEditBase.vue
@@ -1,0 +1,88 @@
+<script setup lang="ts">
+import { reactive, watch } from 'vue'
+
+interface Option {
+  label: string
+  value: string
+}
+
+export type FieldType = 'quiz' | 'flag' | 'data' | 'input' | 'text'
+
+export interface FieldForm {
+  id: number
+  name: string
+  label: string
+  question: string
+  type: FieldType
+  required: boolean
+  points: number
+  placeholder?: string
+  correctCsv: string
+  options: Option[]
+}
+
+const props = defineProps<{ modelValue: FieldForm }>()
+const emit = defineEmits<(e: 'update:modelValue', value: FieldForm) => void>()
+
+const local = reactive({ ...props.modelValue })
+
+watch(
+  () => props.modelValue,
+  (val) => Object.assign(local, val),
+  { deep: true }
+)
+
+watch(
+  local,
+  () => emit('update:modelValue', { ...local }),
+  { deep: true }
+)
+
+const fieldTypes = [
+  { label: 'Quiz', value: 'quiz' },
+  { label: 'Flag', value: 'flag' },
+  { label: 'Data', value: 'data' },
+  { label: 'Input', value: 'input' },
+  { label: 'Text', value: 'text' }
+]
+</script>
+
+<template>
+  <div class="space-y-2">
+    <UInput v-model.number="local.id" type="number" label="Id" disabled />
+    <UInput v-model="local.name" label="Name" />
+    <UInput v-model="local.label" label="Label" />
+    <UInput v-model="local.question" label="Question" />
+    <USelect
+      v-model="local.type"
+      :options="fieldTypes"
+      option-attribute="label"
+      value-attribute="value"
+      label="Type"
+    />
+    <UCheckbox v-model="local.required" label="Required" />
+    <UInput v-model.number="local.points" type="number" label="Points" />
+    <UInput v-model="local.placeholder" label="Placeholder" />
+    <UInput v-model="local.correctCsv" label="Correct (comma separated)" />
+
+    <div v-if="local.type === 'quiz' || local.type === 'flag'" class="space-y-2">
+      <div
+        v-for="(opt, idx) in local.options"
+        :key="idx"
+        class="flex gap-2 items-center"
+      >
+        <UInput v-model="opt.label" label="Option Label" class="flex-1" />
+        <UInput v-model="opt.value" label="Option Value" class="flex-1" />
+        <UButton
+          size="xs"
+          color="red"
+          icon="i-lucide-x"
+          @click="local.options.splice(idx, 1)"
+        />
+      </div>
+      <UButton size="xs" color="primary" @click="local.options.push({ label: '', value: '' })">
+        Add option
+      </UButton>
+    </div>
+  </div>
+</template>

--- a/app/components/fields/data/edit.vue
+++ b/app/components/fields/data/edit.vue
@@ -1,3 +1,8 @@
+<script setup lang="ts">
+import FieldEditBase from '../FieldEditBase.vue'
+const props = defineProps<{ modelValue: any }>()
+const emit = defineEmits(['update:modelValue'])
+</script>
 <template>
-  <div>Data edit component</div>
+  <FieldEditBase :model-value="props.modelValue" @update:modelValue="val => emit('update:modelValue', val)" />
 </template>

--- a/app/components/fields/flag/edit.vue
+++ b/app/components/fields/flag/edit.vue
@@ -1,3 +1,8 @@
+<script setup lang="ts">
+import FieldEditBase from '../FieldEditBase.vue'
+const props = defineProps<{ modelValue: any }>()
+const emit = defineEmits(['update:modelValue'])
+</script>
 <template>
-  <div>Flag edit component</div>
+  <FieldEditBase :model-value="props.modelValue" @update:modelValue="val => emit('update:modelValue', val)" />
 </template>

--- a/app/components/fields/input/edit.vue
+++ b/app/components/fields/input/edit.vue
@@ -1,3 +1,8 @@
+<script setup lang="ts">
+import FieldEditBase from '../FieldEditBase.vue'
+const props = defineProps<{ modelValue: any }>()
+const emit = defineEmits(['update:modelValue'])
+</script>
 <template>
-  <div>Input edit component</div>
+  <FieldEditBase :model-value="props.modelValue" @update:modelValue="val => emit('update:modelValue', val)" />
 </template>

--- a/app/components/fields/quiz/edit.vue
+++ b/app/components/fields/quiz/edit.vue
@@ -1,3 +1,8 @@
+<script setup lang="ts">
+import FieldEditBase from '../FieldEditBase.vue'
+const props = defineProps<{ modelValue: any }>()
+const emit = defineEmits(['update:modelValue'])
+</script>
 <template>
-  <div>Quiz edit component</div>
+  <FieldEditBase :model-value="props.modelValue" @update:modelValue="val => emit('update:modelValue', val)" />
 </template>

--- a/app/components/fields/text/edit.vue
+++ b/app/components/fields/text/edit.vue
@@ -1,3 +1,8 @@
+<script setup lang="ts">
+import FieldEditBase from '../FieldEditBase.vue'
+const props = defineProps<{ modelValue: any }>()
+const emit = defineEmits(['update:modelValue'])
+</script>
 <template>
-  <div>Text edit component</div>
+  <FieldEditBase :model-value="props.modelValue" @update:modelValue="val => emit('update:modelValue', val)" />
 </template>

--- a/app/pages/makeNewTest.vue
+++ b/app/pages/makeNewTest.vue
@@ -20,7 +20,7 @@
 
     <div class="space-y-2">
       <label class="font-bold block">New Field Type</label>
-      <USelect v-model="newFieldType" :options="fieldTypes" option-attribute="label" value-attribute="value" />
+      <USelect v-model="newFieldType" :options="fieldTypes" />
       <div class="flex gap-2 pt-2">
         <UButton color="primary" @click="addField">Add field</UButton>
         <UButton color="primary" @click="submit">Submit</UButton>

--- a/app/pages/makeNewTest.vue
+++ b/app/pages/makeNewTest.vue
@@ -1,15 +1,10 @@
 <template>
   <div class="p-4 space-y-6">
     <!-- Заголовок теста -->
-    <UInput
-      v-model="test.fileName"
-      label="File Name"
-      placeholder="example.json"
-    />
+    <UInput v-model="test.fileName" label="File Name" placeholder="example.json" />
     <UInput v-model="test.title" label="Title" />
     <UTextarea v-model="test.description" label="Description" />
 
-    <!-- Список полей -->
     <div
       v-for="(field, index) in test.fields"
       :key="field.id"
@@ -17,97 +12,24 @@
     >
       <div class="flex justify-between items-center">
         <span class="font-bold">Field {{ index + 1 }}</span>
-        <UButton
-          size="xs"
-          color="red"
-          icon="i-lucide-x"
-          @click="removeField(index)"
-        />
+        <UButton size="xs" color="red" icon="i-lucide-x" @click="removeField(index)" />
       </div>
 
-      <UInput v-model.number="field.id" type="number" label="Id" disabled />
-      <UInput v-model="field.name" label="Name" />
-      <UInput v-model="field.label" label="Label" />
-      <UInput v-model="field.question" label="Question" />
-
-      <!-- Радиокнопки выбора типа -->
-      <label class="font-bold block">Type</label>
-      <div class="flex flex-wrap gap-4">
-        <label
-          v-for="opt in fieldTypes"
-          :key="`${field.id}-${opt.value}`"
-          class="inline-flex items-center gap-1 cursor-pointer"
-        >
-          <input
-            type="radio"
-            :value="opt.value"
-            v-model="field.type"
-            class="h-4 w-4 accent-blue-600"
-          />
-          <span>{{ opt.label }}</span>
-        </label>
-      </div>
-
-      <UCheckbox v-model="field.required" label="Required" />
-      <UInput v-model.number="field.points" type="number" label="Points" />
-      <UInput v-model="field.placeholder" label="Placeholder" />
-      <UInput v-model="field.correctCsv" label="Correct (comma separated)" />
-
-      <!-- Опции -->
-      <div class="space-y-2">
-        <div
-          v-for="(opt, idx) in field.options"
-          :key="idx"
-          class="flex gap-2 items-center"
-        >
-          <UInput v-model="opt.label" label="Option Label" class="flex-1" />
-          <UInput v-model="opt.value" label="Option Value" class="flex-1" />
-          <UButton
-            size="xs"
-            color="red"
-            icon="i-lucide-x"
-            @click="removeOption(field, idx)"
-          />
-        </div>
-        <UButton size="xs" color="primary" @click="addOption(field)"
-          >Add option</UButton
-        >
-      </div>
+      <component :is="getEditComponent(field.type)" v-model="test.fields[index]" />
     </div>
 
-    <!-- Добавление поля -->
     <div class="space-y-2">
       <label class="font-bold block">New Field Type</label>
-      <div class="flex flex-wrap gap-4">
-        <label
-          v-for="opt in fieldTypes"
-          :key="'new-' + opt.value"
-          class="inline-flex items-center gap-1 cursor-pointer"
-        >
-          <input
-            type="radio"
-            :value="opt.value"
-            v-model="newFieldType"
-            class="h-4 w-4 accent-blue-600"
-          />
-          <span>{{ opt.label }}</span>
-        </label>
-      </div>
-
+      <USelect v-model="newFieldType" :options="fieldTypes" option-attribute="label" value-attribute="value" />
       <div class="flex gap-2 pt-2">
         <UButton color="primary" @click="addField">Add field</UButton>
         <UButton color="primary" @click="submit">Submit</UButton>
       </div>
     </div>
 
-    <!-- Превью JSON -->
-    <pre class="bg-neutral-200 p-2 text-xs overflow-auto"
-      >{{ JSON.stringify(preview, null, 2) }}
-</pre
-    >
+    <pre class="bg-neutral-200 p-2 text-xs overflow-auto">{{ JSON.stringify(preview, null, 2) }}</pre>
   </div>
 </template>
-
 <script lang="ts" setup>
 import { reactive, computed, ref } from "vue";
 import { useToast } from "#imports";
@@ -140,6 +62,15 @@ interface FieldForm {
   correctCsv: string;
   options: Option[];
 }
+
+const getEditComponent = (type: FieldType) =>
+  ({
+    quiz: 'FieldsQuizEdit',
+    flag: 'FieldsFlagEdit',
+    data: 'FieldsDataEdit',
+    input: 'FieldsInputEdit',
+    text: 'FieldsTextEdit',
+  }[type]);
 
 /* ---------- Состояние ---------- */
 const newFieldType = ref<FieldType>("text");
@@ -177,14 +108,6 @@ function addField() {
 
 function removeField(index: number) {
   test.fields.splice(index, 1);
-}
-
-function addOption(field: FieldForm) {
-  field.options.push({ label: "", value: "" });
-}
-
-function removeOption(field: FieldForm, idx: number) {
-  field.options.splice(idx, 1);
 }
 
 /* ---------- Превью ---------- */

--- a/app/pages/test/[id]/edit.vue
+++ b/app/pages/test/[id]/edit.vue
@@ -20,7 +20,7 @@
 
     <div class="space-y-2">
       <label class="font-bold block">New Field Type</label>
-      <USelect v-model="newFieldType" :options="fieldTypes" option-attribute="label" value-attribute="value" />
+      <USelect v-model="newFieldType" :options="fieldTypes" />
       <div class="flex gap-2 pt-2">
         <UButton color="primary" @click="addField">Add field</UButton>
         <UButton color="primary" @click="submit">Submit</UButton>

--- a/app/pages/test/[id]/edit.vue
+++ b/app/pages/test/[id]/edit.vue
@@ -1,14 +1,10 @@
 <template>
   <div class="p-4 space-y-6">
     <!-- Заголовок теста -->
-    <UInput
-      v-model="test.fileName"
-      disabled
-    />
+    <UInput v-model="test.fileName" disabled />
     <UInput v-model="test.title" label="Title" />
     <UTextarea v-model="test.description" label="Description" />
 
-    <!-- Список полей -->
     <div
       v-for="(field, index) in test.fields"
       :key="field.id"
@@ -16,97 +12,24 @@
     >
       <div class="flex justify-between items-center">
         <span class="font-bold">Field {{ index + 1 }}</span>
-        <UButton
-          size="xs"
-          color="red"
-          icon="i-lucide-x"
-          @click="removeField(index)"
-        />
+        <UButton size="xs" color="red" icon="i-lucide-x" @click="removeField(index)" />
       </div>
 
-      <UInput v-model.number="field.id" type="number" label="Id" disabled />
-      <UInput v-model="field.name" label="Name" />
-      <UInput v-model="field.label" label="Label" />
-      <UInput v-model="field.question" label="Question" />
-
-      <!-- Радиокнопки выбора типа -->
-      <label class="font-bold block">Type</label>
-      <div class="flex flex-wrap gap-4">
-        <label
-          v-for="opt in fieldTypes"
-          :key="`${field.id}-${opt.value}`"
-          class="inline-flex items-center gap-1 cursor-pointer"
-        >
-          <input
-            type="radio"
-            :value="opt.value"
-            v-model="field.type"
-            class="h-4 w-4 accent-blue-600"
-          />
-          <span>{{ opt.label }}</span>
-        </label>
-      </div>
-
-      <UCheckbox v-model="field.required" label="Required" />
-      <UInput v-model.number="field.points" type="number" label="Points" />
-      <UInput v-model="field.placeholder" label="Placeholder" />
-      <UInput v-model="field.correctCsv" label="Correct (comma separated)" />
-
-      <!-- Опции -->
-      <div class="space-y-2">
-        <div
-          v-for="(opt, idx) in field.options"
-          :key="idx"
-          class="flex gap-2 items-center"
-        >
-          <UInput v-model="opt.label" label="Option Label" class="flex-1" />
-          <UInput v-model="opt.value" label="Option Value" class="flex-1" />
-          <UButton
-            size="xs"
-            color="red"
-            icon="i-lucide-x"
-            @click="removeOption(field, idx)"
-          />
-        </div>
-        <UButton size="xs" color="primary" @click="addOption(field)"
-          >Add option</UButton
-        >
-      </div>
+      <component :is="getEditComponent(field.type)" v-model="test.fields[index]" />
     </div>
 
-    <!-- Добавление поля -->
     <div class="space-y-2">
       <label class="font-bold block">New Field Type</label>
-      <div class="flex flex-wrap gap-4">
-        <label
-          v-for="opt in fieldTypes"
-          :key="'new-' + opt.value"
-          class="inline-flex items-center gap-1 cursor-pointer"
-        >
-          <input
-            type="radio"
-            :value="opt.value"
-            v-model="newFieldType"
-            class="h-4 w-4 accent-blue-600"
-          />
-          <span>{{ opt.label }}</span>
-        </label>
-      </div>
-
+      <USelect v-model="newFieldType" :options="fieldTypes" option-attribute="label" value-attribute="value" />
       <div class="flex gap-2 pt-2">
         <UButton color="primary" @click="addField">Add field</UButton>
         <UButton color="primary" @click="submit">Submit</UButton>
       </div>
     </div>
 
-    <!-- Превью JSON -->
-    <pre class="bg-neutral-200 p-2 text-xs overflow-auto"
-      >{{ JSON.stringify(preview, null, 2) }}
-</pre
-    >
+    <pre class="bg-neutral-200 p-2 text-xs overflow-auto">{{ JSON.stringify(preview, null, 2) }}</pre>
   </div>
 </template>
-
 <script lang="ts" setup>
 import { reactive, computed, ref } from "vue";
 import { useToast } from "#imports";
@@ -143,6 +66,15 @@ interface FieldForm {
   correctCsv: string;
   options: Option[];
 }
+
+const getEditComponent = (type: FieldType) =>
+  ({
+    quiz: 'FieldsQuizEdit',
+    flag: 'FieldsFlagEdit',
+    data: 'FieldsDataEdit',
+    input: 'FieldsInputEdit',
+    text: 'FieldsTextEdit',
+  }[type]);
 
 /* ---------- Состояние ---------- */
 const newFieldType = ref<FieldType>("text");
@@ -200,13 +132,6 @@ function removeField(index: number) {
   test.fields.splice(index, 1);
 }
 
-function addOption(field: FieldForm) {
-  field.options.push({ label: "", value: "" });
-}
-
-function removeOption(field: FieldForm, idx: number) {
-  field.options.splice(idx, 1);
-}
 
 /* ---------- Превью ---------- */
 const preview = computed(() => ({


### PR DESCRIPTION
## Summary
- add reusable `FieldEditBase` to render editing fields
- use new edit components for each field type
- refactor test edit page to render field cards via edit components
- refactor new-test page similarly and switch type selectors to dropdowns

## Testing
- `pnpm lint` *(fails: Cannot find module '/workspace/TestingApp/.nuxt/eslint.config.mjs')*

------
https://chatgpt.com/codex/tasks/task_e_686362c1f1908322bee319512f8f394e